### PR TITLE
Stream when bulk uploading to Solr with curl

### DIFF
--- a/linkml_solr/utils/solr_bulkload.py
+++ b/linkml_solr/utils/solr_bulkload.py
@@ -35,7 +35,7 @@ def bulkload_file(f,
         ct = 'application/json'
     else:
         raise Exception(f'Unknown format {format}')
-    command = ['curl', url, '--data-binary', f'@{f}', '-H', f'Content-type:{ct}']
+    command = ['curl', url, '-T', f'{f}', '-X', 'POST', '-H', f'Content-type:{ct}']
     print(command)
     subprocess.run(command)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "linkml-solr"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["Chris Mungall <cjm@berkeleybop.org>"]
 


### PR DESCRIPTION
Adding the `-T <filename>` with `-X POST` puts curl into a streaming mode, which solved an out of memory error I was hitting. 